### PR TITLE
Fix random closing of tabs

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,6 +89,13 @@
           "type": "boolean",
           "default": false,
           "description": "Use Markdown Editor as the default editor for markdown files."
+        },
+        "markdown-editor.disposalTimeoutSeconds": {
+          "type": "number",
+          "default": 10,
+          "minimum": 1,
+          "maximum": 60,
+          "description": "Time in seconds to wait before disposing a panel after its document is closed"
         }
       }
     },


### PR DESCRIPTION
This PR provides a fix to mitigate the issue that the visible tabs get closed randomly. 

The behaviour seems to origin from VSCode internal process: 
```
at Xw.acceptDocumentsAndEditorsDelta (file:///usr/share/code/resources/app/out/vs/workbench/api/node/extensionHostProcess.js:119:11592)
at Xw.$acceptDocumentsAndEditorsDelta (file:///usr/share/code/resources/app/out/vs/workbench/api/node/extensionHostProcess.js:119:10210)
```

`acceptDocumentsAndEditorsDelta` indicates that VS Code is synchronizing its document and editor state, and the issue appears to be related to how VS Code handles custom editors and document synchronization. 

The fix adds a delay (of about 10s) to disposing the document when the document is closed. The fix improves the situation noticeably. 